### PR TITLE
Correcoes na busca de CEP

### DIFF
--- a/app/design/frontend/base/default/template/onepagecheckout/onepage/billing.phtml
+++ b/app/design/frontend/base/default/template/onepagecheckout/onepage/billing.phtml
@@ -544,7 +544,7 @@ $has_addr	= $this->customerHasAddresses();
 
       var temcep = $j('input[name*="[postcode]"]').val();
       if(temcep != ""){
-          buscarEndereco('http://onestepcheckout.com.br/beta3/skin/','billing');
+          buscarEndereco('<?php echo Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_SKIN);?>','billing');
       }
 
 //]]>

--- a/app/design/frontend/base/default/template/onepagecheckout/onepage/shipping.phtml
+++ b/app/design/frontend/base/default/template/onepagecheckout/onepage/shipping.phtml
@@ -43,7 +43,7 @@ if (!$this->getQuote()->isVirtual() && Mage::helper('onepagecheckout')->isShippi
 <ul>
     <li class="options">
         <input type="checkbox" class="checkbox" name="shipping[same_as_billing]" id="shipping:same_as_billing" value="1"<?php if($this->getShipAddress()->getSameAsBilling()){echo ' checked="checked" ';} ?> title="<?php echo $this->__('Ship to this address') ?>" onclick="shipping.setSameAsBilling(this.checked)" />
-        <label>
+        <label for="shipping:same_as_billing">
         	<?php echo $this->__('Ship to this address') ?>
         </label>
     </li>

--- a/skin/frontend/base/default/deivison/buscacep.php
+++ b/skin/frontend/base/default/deivison/buscacep.php
@@ -59,7 +59,9 @@ function simple_curl($url,$post=array(),$get=array()){
 	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 	return curl_exec ($ch);
 }
-
+if(!isset($_GET['cep']) OR empty($_GET['cep'])){
+    exit;
+}
 ///////////////////////////////////////////////////
 //MONTA URL A SER EXPLORADA
 ///////////////////////////////////////////////////
@@ -90,8 +92,8 @@ $dados =
 //SEPARA A CIDADE DA UF DO RESULTADO ACIMA
 ///////////////////////////////////////////////////
   $dados['cidade/uf'] = explode('/',$dados['cidade/uf']);
-  $dados['cidade'] = trim($dados['cidade/uf'][0]);
-  $dados['uf'] = trim($dados['cidade/uf'][1]);
+  $dados['cidade'] = trim(@$dados['cidade/uf'][0]);
+  $dados['uf'] = trim(@$dados['cidade/uf'][1]);
   unset($dados['cidade/uf']);
 
 ///////////////////////////////////////////////////
@@ -170,7 +172,7 @@ if ( isset($dados) ) {
             ('BR', 'TO', 'Tocantins'),
             ('BR', 'DF', 'Distrito Federal');
 */
-        $texto = $dados['logradouro'].":".$dados['bairro'].":".$dados['cidade'].":".$estado.":".$num.";";
+        $texto = $dados['logradouro'].":".$dados['bairro'].":".$dados['cidade'].":".@$estado.":".@$num.";";
         echo $texto;
 
 }else {


### PR DESCRIPTION
Correcao na chamada da busca de cep que chamada o onestepcheckout.com.br retornando 404 nos casos onde o CEP já estava preenchido.
Melhoria simples no label de 'Shop to this address'. Agora ele é clicável.
Correcoes no sistema de busca de cep que exibia notices e erros em casos de cep em branco ou inválidos em sistemas com error_reporting E_NOTICES habilitado.
