### PR TITLE
Limpeza de campo CEP comentada

### DIFF
--- a/skin/frontend/base/default/deivison/deivison.js
+++ b/skin/frontend/base/default/deivison/deivison.js
@@ -39,9 +39,10 @@
 
             //Ao se coloca o "-" no CEP não irá calcular o frete caso use o módulo Matrix Rates, pois ele não trabalha com o "-"
             /*Essa opção é caso queira que toda vez ao se entrar no campo ele limpe-o*/
-            $j('input[class*="tracoAtivo"]').focus(function(){
-              $j(this).val('');
-            });
+
+            //$j('input[class*="tracoAtivo"]').focus(function(){
+            //  $j(this).val('');
+            //});
 
              /*Script do traço do cep*/
             $j('input[class*="tracoAtivo"]').keydown( function(e){


### PR DESCRIPTION
A Maioria das pessoas preferem como padrão sem limpeza automatica e identificam essa função como um bug, então deixei comentado para caso queiram utilizar posteriormente o desenvolvedor poder descomentar.
